### PR TITLE
change password support

### DIFF
--- a/resources/lang/en/field.php
+++ b/resources/lang/en/field.php
@@ -40,6 +40,18 @@ return [
     'confirm_password' => [
         'name' => 'Confirm Password',
     ],
+    'password_old'         => [
+        'name'         => 'Old Password',
+        'instructions' => 'Specify current password.',
+    ],
+    'password_new'         => [
+        'name'         => 'New Password',
+        'instructions' => 'Specify new password.',
+    ],
+    'password_new_confirmation' => [
+        'name'         => 'Confirm New Password',
+        'instructions' => 'Specify new password again.',
+    ],
     'slug'             => [
         'name'         => 'Slug',
         'instructions' => [

--- a/resources/lang/en/message.php
+++ b/resources/lang/en/message.php
@@ -11,4 +11,6 @@ return [
     'invalid_email'            => 'An account with the provided email could not be found.',
     'pending_admin_activation' => 'Your account is pending activation from an administrator.',
     'confirm_reset_password'   => 'Please check your email to finish resetting your password.',
+    'invalid_password_old'     => 'Invalid old password.',
+    'confirm_password_change'  => 'Your password has been changed.',
 ];

--- a/resources/views/password/change.twig
+++ b/resources/views/password/change.twig
@@ -1,0 +1,7 @@
+{% extends layout('users') %}
+
+{% block content %}
+
+    {{ form('change_password') }}
+
+{% endblock %}

--- a/src/Http/Controller/PasswordController.php
+++ b/src/Http/Controller/PasswordController.php
@@ -14,6 +14,16 @@ class PasswordController extends PublicController
 {
 
     /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->middleware('auth')->only('change');
+
+        parent::__construct();
+    }
+
+    /**
      * Return a forgot password view.
      */
     public function forgot()
@@ -29,5 +39,15 @@ class PasswordController extends PublicController
     public function reset()
     {
         return $this->view->make('anomaly.module.users::password/reset');
+    }
+
+    /**
+     * Change a logged-user password.
+     *
+     * @return \Illuminate\Contracts\View\View|mixed
+     */
+    public function change()
+    {
+        return $this->view->make('anomaly.module.users::password/change');
     }
 }

--- a/src/User/Password/ChangePasswordFormBuilder.php
+++ b/src/User/Password/ChangePasswordFormBuilder.php
@@ -1,0 +1,39 @@
+<?php namespace Anomaly\UsersModule\User\Password;
+
+use Anomaly\Streams\Platform\Ui\Form\FormBuilder;
+use Illuminate\Contracts\Config\Repository;
+
+/**
+ * Class ChangePasswordFormBuilder
+ *
+ * @link          http://pyrocms.com/
+ * @author        PyroCMS, Inc. <support@pyrocms.com>
+ * @author        Ryan Thompson <ryan@pyrocms.com>
+ */
+class ChangePasswordFormBuilder extends FormBuilder
+{
+
+    /**
+     * No model.
+     *
+     * @var bool
+     */
+    protected $model = false;
+
+    /**
+     * The form actions.
+     *
+     * @var array
+     */
+    protected $actions = [
+        'submit',
+    ];
+
+    /**
+     * The form options.
+     *
+     * @var array
+     */
+    protected $options = [
+    ];
+}

--- a/src/User/Password/ChangePasswordFormFields.php
+++ b/src/User/Password/ChangePasswordFormFields.php
@@ -1,0 +1,60 @@
+<?php namespace Anomaly\UsersModule\User\Password;
+
+/**
+ * Class ForgotPasswordFormFields
+ *
+ * @link          http://pyrocms.com/
+ * @author        PyroCMS, Inc. <support@pyrocms.com>
+ * @author        Ryan Thompson <ryan@pyrocms.com>
+ */
+class ChangePasswordFormFields
+{
+
+    /**
+     * Handle the fields.
+     *
+     * @param ChangePasswordFormBuilder $builder
+     */
+    public function handle(ChangePasswordFormBuilder $builder)
+    {
+        $builder->setFields(
+            [
+                'password_old' => [
+                    'type' => 'anomaly.field_type.text',
+                    'label' => 'anomaly.module.users::field.password_old.name',
+                    'config' => [
+                        'type' => 'password',
+                    ],
+                    'required' => true,
+                    'rules' => [
+                        'required|valid_password_old',
+                    ],
+                    'validators' => [
+                        'valid_password_old' => [
+                            'handler' => 'Anomaly\UsersModule\User\Validation\ValidateCurrentPassword@handle',
+                            'message' => 'anomaly.module.users::message.invalid_password_old',
+                        ],
+                    ],
+                ],
+                'password_new' => [
+                    'type' => 'anomaly.field_type.text',
+                    'label' => 'anomaly.module.users::field.password_new.name',
+                    'config' => [
+                        'type' => 'password',
+                    ],
+                    'required' => true,
+                    'rules' => [
+                        'confirmed',
+                    ],
+                ],
+                'password_new_confirmation' => [
+                    'type' => 'anomaly.field_type.text',
+                    'label' => 'anomaly.module.users::field.password_new.name',
+                    'config' => [
+                        'type' => 'password',
+                    ],
+                ],
+            ]
+        );
+    }
+}

--- a/src/User/Password/ChangePasswordFormHandler.php
+++ b/src/User/Password/ChangePasswordFormHandler.php
@@ -1,0 +1,41 @@
+<?php namespace Anomaly\UsersModule\User\Password;
+
+use Anomaly\Streams\Platform\Message\MessageBag;
+use Anomaly\UsersModule\User\Contract\UserRepositoryInterface;
+use Illuminate\Http\Request;
+
+/**
+ * Class ChangePasswordFormHandler
+ *
+ * @link          http://pyrocms.com/
+ * @author        PyroCMS, Inc. <support@pyrocms.com>
+ * @author        Ryan Thompson <ryan@pyrocms.com>
+ */
+class ChangePasswordFormHandler
+{
+
+    /**
+     * Handle the form.
+     *
+     * @param Request $request
+     * @param ChangePasswordFormBuilder|ForgotPasswordFormBuilder $builder
+     * @param UserRepositoryInterface $users
+     * @param MessageBag $messages
+     */
+    public function handle(
+        Request $request,
+        ChangePasswordFormBuilder $builder,
+        UserRepositoryInterface $users,
+        MessageBag $messages
+    ) {
+        if ($builder->hasFormErrors()) {
+            return;
+        }
+
+        $user = $request->user();
+        $user->password = $builder->getFormValue('password_new');
+        $user->save();
+
+        $messages->success('anomaly.module.users::message.confirm_password_change');
+    }
+}

--- a/src/User/Validation/ValidateCurrentPassword.php
+++ b/src/User/Validation/ValidateCurrentPassword.php
@@ -1,0 +1,37 @@
+<?php namespace Anomaly\UsersModule\User\Validation;
+
+use Anomaly\UsersModule\User\Password\ChangePasswordFormBuilder;
+use Anomaly\UsersModule\User\UserAuthenticator;
+use Illuminate\Contracts\Auth\Guard;
+
+/**
+ * Class ValidateCredentials
+ *
+ * @link          http://pyrocms.com/
+ * @author        PyroCMS, Inc. <support@pyrocms.com>
+ * @author        Ryan Thompson <ryan@pyrocms.com>
+ */
+class ValidateCurrentPassword
+{
+
+    /**
+     * Handle the validation.
+     *
+     * @param  UserAuthenticator $authenticator
+     * @param  ChangePasswordFormBuilder $builder
+     * @return bool
+     */
+    public function handle(Guard $guard, UserAuthenticator $authenticator, ChangePasswordFormBuilder $builder)
+    {
+        $credentials = [
+            'email' => $guard->user()->email,
+            'password' => $builder->getFormValues()->get('password_old'),
+        ];
+
+        if (! $response = $authenticator->authenticate($credentials)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/UsersModuleServiceProvider.php
+++ b/src/UsersModuleServiceProvider.php
@@ -68,6 +68,10 @@ class UsersModuleServiceProvider extends AddonServiceProvider
             'as'   => 'anomaly.module.users::users.activate',
             'uses' => 'Anomaly\UsersModule\Http\Controller\RegisterController@activate',
         ],
+        'users/password/change'               => [
+            'as'   => 'anomaly.module.users::users.change',
+            'uses' => 'Anomaly\UsersModule\Http\Controller\PasswordController@change',
+        ],
         'users/password/reset'               => [
             'as'   => 'anomaly.module.users::users.reset',
             'uses' => 'Anomaly\UsersModule\Http\Controller\PasswordController@reset',
@@ -111,6 +115,7 @@ class UsersModuleServiceProvider extends AddonServiceProvider
         'register'                                                  => 'Anomaly\UsersModule\User\Register\RegisterFormBuilder',
         'reset_password'                                            => 'Anomaly\UsersModule\User\Password\ResetPasswordFormBuilder',
         'forgot_password'                                           => 'Anomaly\UsersModule\User\Password\ForgotPasswordFormBuilder',
+        'change_password'                                           => 'Anomaly\UsersModule\User\Password\ChangePasswordFormBuilder',
         'Illuminate\Auth\Middleware\Authenticate'                   => 'Anomaly\UsersModule\Http\Middleware\Authenticate',
         'Anomaly\Streams\Platform\Http\Middleware\Authenticate'     => 'Anomaly\UsersModule\Http\Middleware\Authenticate',
         'Anomaly\Streams\Platform\Model\Users\UsersUsersEntryModel' => 'Anomaly\UsersModule\User\UserModel',


### PR DESCRIPTION
Hello,

this is initial support to change password.

Form handler could be improved I think?
```php
$user = $request->user();
        $user->password = $builder->getFormValue('password_new');
        $user->save();
```

Also checking for old password: \Anomaly\UsersModule\User\Validation\ValidateCurrentPassword probably could be somehow improved.

I was not sure of the correct way to check 'login' field, so we actually compare current users login + password provided...

Maybe we should just check current users ID, then find this user in db, and compare the pass somehow?

Thanks :)