### PR TITLE
fix non-localized logout

### DIFF
--- a/src/Http/Controller/LoginController.php
+++ b/src/Http/Controller/LoginController.php
@@ -39,6 +39,6 @@ class LoginController extends PublicController
 
         $this->messages->success($this->request->get('message', 'anomaly.module.users::message.logged_out'));
 
-        return $this->response->redirectTo($this->request->get('redirect', '/'));
+        return $this->response->redirectTo((url($this->request->get('redirect', '/'))));
     }
 }


### PR DESCRIPTION
Problem. When user is browsing in non-default locale, logout will redirect always to non-localized uri