### PR TITLE
Modified for Login As function

### DIFF
--- a/resources/lang/en/button.php
+++ b/resources/lang/en/button.php
@@ -10,4 +10,5 @@ return [
     'add_field'      => 'Add Field',
     'permissions'    => 'Permissions',
     'reset_password' => 'Reset Password',
+    'login_as'       => 'Login As',
 ];

--- a/resources/lang/en/message.php
+++ b/resources/lang/en/message.php
@@ -12,4 +12,6 @@ return [
     'invalid_email'            => 'An account with the provided email could not be found.',
     'pending_admin_activation' => 'Your account is pending activation from an administrator.',
     'confirm_reset_password'   => 'Please check your email to finish resetting your password.',
+    'no_user_found'            => 'We could not find that user id',
+    'not_an_admin'             => 'You do not appear to be an administrator',
 ];

--- a/src/Http/Controller/Admin/UsersController.php
+++ b/src/Http/Controller/Admin/UsersController.php
@@ -2,8 +2,10 @@
 
 use Anomaly\Streams\Platform\Http\Controller\AdminController;
 use Anomaly\UsersModule\User\Form\UserFormBuilder;
+use Anomaly\UsersModule\User\Contract\UserRepositoryInterface;
 use Anomaly\UsersModule\User\Permission\PermissionFormBuilder;
 use Anomaly\UsersModule\User\Table\UserTableBuilder;
+use Auth;
 
 /**
  * Class UsersController
@@ -62,5 +64,27 @@ class UsersController extends AdminController
     public function permissions(PermissionFormBuilder $form, $id)
     {
         return $form->render($id);
+    }
+
+    /**
+     * Login the admin user as a different user and redirect.
+     *
+     * @param                                             $id
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function loginAs(UserRepositoryInterface $users, $id)
+    {
+        if(@Auth::user() && @Auth::user()->hasRole('admin'))
+        {
+            $user = $users->find($id);
+            if ($user) {
+                Auth::login($user);
+                return redirect()->to('/');
+            } else {
+                return redirect()->back()->with('error',trans('anomaly.module.users::message.no_user_found'));
+            }
+        } else {
+            return redirect()->back()->with('error',trans('anomaly.module.users::message.not_an_admin'));
+        }
     }
 }

--- a/src/User/Table/UserTableBuilder.php
+++ b/src/User/Table/UserTableBuilder.php
@@ -74,6 +74,11 @@ class UserTableBuilder extends TableBuilder
             'icon'   => 'lock',
             'href'   => 'admin/users/permissions/{entry.id}',
         ],
+        'login_as' => [
+            'button' => 'primary',
+            'icon'   => 'sign-in',
+            'href'   => 'admin/users/loginas/{entry.id}',
+        ],
     ];
 
 }

--- a/src/UsersModuleServiceProvider.php
+++ b/src/UsersModuleServiceProvider.php
@@ -92,6 +92,7 @@ class UsersModuleServiceProvider extends AddonServiceProvider
         'admin/users/edit/{id}'              => 'Anomaly\UsersModule\Http\Controller\Admin\UsersController@edit',
         'admin/users/delete/{id}'            => 'Anomaly\UsersModule\Http\Controller\Admin\UsersController@delete',
         'admin/users/permissions/{id}'       => 'Anomaly\UsersModule\Http\Controller\Admin\UsersController@permissions',
+        'admin/users/loginas/{id}'           => 'Anomaly\UsersModule\Http\Controller\Admin\UsersController@loginAs',
         'admin/users/activate/{id}'          => 'Anomaly\UsersModule\Http\Controller\Admin\UsersController@activate',
         'admin/users/deactivate/{id}'        => 'Anomaly\UsersModule\Http\Controller\Admin\UsersController@deactivate',
         'admin/users/block/{id}'             => 'Anomaly\UsersModule\Http\Controller\Admin\UsersController@block',


### PR DESCRIPTION
I added an button to the Users admin panel table that says "Login As" and uses the icon "sign-in". So far I've only done the English translation.

This also assumes that there is a role called "admin" which is there by default. Not sure if there's a better way or not. Could maybe add a role permission called "Can Login in As" or something.