### PR TITLE
Feature/manage permissions

### DIFF
--- a/resources/config/permissions.php
+++ b/resources/config/permissions.php
@@ -7,6 +7,7 @@ return [
         'write_admins',
         'impersonate',
         'delete',
+        'manage_permissions'
     ],
     'roles'    => [
         'read',

--- a/resources/lang/en/permission.php
+++ b/resources/lang/en/permission.php
@@ -10,6 +10,7 @@ return [
             'impersonate'  => 'Can impersonate other users.',
             'reset'        => 'Can reset users.',
             'delete'       => 'Can delete users.',
+            'manage_permissions' => 'Can manage a user\'s permissions.',
         ],
     ],
     'roles'    => [

--- a/src/Http/Controller/Admin/UsersController.php
+++ b/src/Http/Controller/Admin/UsersController.php
@@ -64,8 +64,12 @@ class UsersController extends AdminController
      * @param                                             $id
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function permissions(PermissionFormBuilder $form, $id)
+    public function permissions(Authorizer $authorizer, PermissionFormBuilder $form, $id)
     {
+        if (!$authorizer->authorize('anomaly.module.users::users.manage_permissions')) {
+            abort(403);
+        }
+
         return $form->render($id);
     }
 

--- a/src/User/Table/UserTableBuilder.php
+++ b/src/User/Table/UserTableBuilder.php
@@ -146,6 +146,7 @@ class UserTableBuilder extends TableBuilder
                 'permissions' => [
                     'button' => 'info',
                     'href'   => 'admin/users/permissions/{entry.id}',
+                    'permission' => 'anomaly.module.users::users.manage_permissions',
                 ],
                 'impersonate' => [
                     'text'       => 'anomaly.module.users::button.login_as_user',


### PR DESCRIPTION
This allows a user to be able to edit user info while avoiding the risk that they could escalate their own permissions to admin level and gain access to all parts of the CMS.

Hides the permissions button in the users table dropdown and the roles field in the users form if the logged in user doesn't have the new `manage_permissions` permission.