### PR TITLE
object is converted to array without relations

### DIFF
--- a/src/User/Notification/ActivateYourAccount.php
+++ b/src/User/Notification/ActivateYourAccount.php
@@ -54,7 +54,7 @@ class ActivateYourAccount extends Notification implements ShouldQueue
      */
     public function toMail(UserInterface $notifiable)
     {
-        $data = $notifiable->toArray();
+        $data = $notifiable->attributesToArray();
 
         return (new MailMessage())
             ->view('anomaly.module.users::notifications.activate_your_account')

--- a/src/User/Notification/PasswordInvalidated.php
+++ b/src/User/Notification/PasswordInvalidated.php
@@ -54,7 +54,7 @@ class PasswordInvalidated extends Notification implements ShouldQueue
      */
     public function toMail(UserInterface $notifiable)
     {
-        $data = $notifiable->toArray();
+        $data = $notifiable->attributesToArray();
 
         return (new MailMessage())
             ->error()

--- a/src/User/Notification/ResetYourPassword.php
+++ b/src/User/Notification/ResetYourPassword.php
@@ -54,7 +54,7 @@ class ResetYourPassword extends Notification implements ShouldQueue
      */
     public function toMail(UserInterface $notifiable)
     {
-        $data = $notifiable->toArray();
+        $data = $notifiable->attributesToArray();
 
         return (new MailMessage())
             ->error()

--- a/src/User/Notification/UserHasBeenActivated.php
+++ b/src/User/Notification/UserHasBeenActivated.php
@@ -37,7 +37,7 @@ class UserHasBeenActivated extends Notification implements ShouldQueue
      */
     public function toMail(UserInterface $notifiable)
     {
-        $data = $notifiable->toArray();
+        $data = $notifiable->attributesToArray();
 
         return (new MailMessage())
             ->view('anomaly.module.users::notifications.user_has_been_activated')

--- a/src/User/Notification/UserHasRegistered.php
+++ b/src/User/Notification/UserHasRegistered.php
@@ -56,7 +56,7 @@ class UserHasRegistered extends Notification implements ShouldQueue
      */
     public function toMail(AnonymousNotifiable $notifiable)
     {
-        $data = $this->user->toArray();
+        $data = $this->user->attributesToArray();
 
         return (new MailMessage())
             ->view('anomaly.module.users::notifications.user_has_registered')

--- a/src/User/Notification/UserPendingActivation.php
+++ b/src/User/Notification/UserPendingActivation.php
@@ -54,7 +54,7 @@ class UserPendingActivation extends Notification implements ShouldQueue
      */
     public function toMail(AnonymousNotifiable $notifiable)
     {
-        $data = $this->user->toArray();
+        $data = $this->user->attributesToArray();
 
         return (new MailMessage())
             ->view('anomaly.module.users::notifications.user_pending_activation')


### PR DESCRIPTION
**Errors in password reset and similar notifications.**

![image](https://user-images.githubusercontent.com/39536659/202452847-63aa68b0-a09e-49ed-9140-f6b3bdb2d48d.png)

<hr>

**vendor/anomaly/users-module/src/User/UserModel.php:37**
![image](https://user-images.githubusercontent.com/39536659/202453417-751cfe8d-0a26-494b-9cae-909fa6fefc05.png)




**Object is converted to array without relations.
The replace parameter in the trans function does not accept the array.**



@RyanThompson 

